### PR TITLE
Add 'aws-sdk' installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # aws-cloudwatch-metric-count
 
-To run it just type:
+To run it, simply clone this repo and then:
 
+    npm install aws-sdk
     node index.js
 
 Provided your environment has proper AWS credentials (for example [Configuration and credential file settings](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html)) set and permissions to Cloudwatch [`listMetrics`](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/CloudWatch.html#listMetrics-property) and [`getMetricStatistics`](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/CloudWatch.html#getMetricStatistics-property)


### PR DESCRIPTION
Without installing the sdk first I get this error:

```
$ node index.js
internal/modules/cjs/loader.js:883
  throw err;
  ^

Error: Cannot find module 'aws-sdk'
```

After installing the sdk everything works fine!
