### PR TITLE
Stop using recursion so that call stack limit is not reached

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -163,6 +163,11 @@
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
+    "blend-promise-utils": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/blend-promise-utils/-/blend-promise-utils-1.28.0.tgz",
+      "integrity": "sha512-OFqOTxHXfukQyZYl6kslVQaTKXrbZKP7Ak9yZzliDWUoHgV4D9HHo85lUTMsPiP+RzToE39rYr8qzJMgJxphLQ=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "eslint-plugin-standard": "^4.0.1"
   },
   "dependencies": {
-    "aws-sdk": "^2.814.0"
+    "aws-sdk": "^2.814.0",
+    "blend-promise-utils": "^1.28.0"
   }
 }


### PR DESCRIPTION
When I tried using the script to pull metrics from one of our AWS accounts, I ran into the following:
```
Iteration #831, 415000 metrics
Iteration #832, 415500 metrics
error: RangeError: Maximum call stack size exceeded
```
So I made these changes to strip out the recursion.